### PR TITLE
Fix Facebook like button placement and link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,9 +25,10 @@
 		<!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->
 		</div>
 	</head>
-	<body>
+       <body>
+               <div id="fb-root"></div>
 
-		<!-- Page Wrapper -->
+               <!-- Page Wrapper -->
 			<div id="page-wrapper">
 
 				<!-- Header -->
@@ -50,21 +51,21 @@
 						</div>
 					</nav>
 
-				<!-- Banner -->
-					<section id="banner">
-						<div class="inner">
-							<div class="logo"><img src="images/logo.png" height="42" width="42"></div>
-							<h2>Innovation Foundry</h2>
-							<!-- <p>Another free + fully responsive site template by <a href="http://html5up.net">HTML5 UP</a></p> -->
-						</div>
-						<!-- Your like button code -->
-						<div class="fb-like"
-							data-href="http://www.your-domain.com/your-page.html"
-							data-layout="standard"
-							data-action="like"
-							data-show-faces="true">
-						</div>
-					</section>
+                               <!-- Banner -->
+                                       <section id="banner">
+                                               <div class="inner">
+                                                       <div class="logo"><img src="images/logo.png" height="42" width="42"></div>
+                                                       <h2>Innovation Foundry</h2>
+                                                       <!-- <p>Another free + fully responsive site template by <a href="http://html5up.net">HTML5 UP</a></p> -->
+                                                       <div class="fb-like"
+                                                               data-href="https://www.facebook.com/Innovation-Foundry-Inc-288025034691393/"
+                                                               data-layout="standard"
+                                                               data-action="like"
+                                                               data-show-faces="true"
+                                                               data-share="true">
+                                                       </div>
+                                               </div>
+                                       </section>
 
 				<!-- Wrapper -->
 					<section id="wrapper">
@@ -192,12 +193,13 @@
 								<li>&copy; Innovation Foundry Inc. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 
 							</ul>
-							<div
-							  class="fb-like"
-							  data-share="true"
-							  data-width="450"
-							  data-show-faces="true">
-							</div>
+                                                       <div
+                                                         class="fb-like"
+                                                         data-href="https://www.facebook.com/Innovation-Foundry-Inc-288025034691393/"
+                                                         data-share="true"
+                                                         data-width="450"
+                                                         data-show-faces="true">
+                                                       </div>
 						</div>
 					</section>
 


### PR DESCRIPTION
## Summary
- Add `fb-root` div to enable Facebook SDK
- Move like button inside banner and point to Innovation Foundry page
- Update footer like button to use correct page URL

## Testing
- `npm test` *(fails: notEqual at test.js:24 and test.js:25)*

------
https://chatgpt.com/codex/tasks/task_e_688eaac5e9e48327bed3000f61b0c486