### PR TITLE
Serve static index page from public directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,10 @@ app.use((req, res, next) => {
 app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');
 
-app.get('/', function(request, response) {
-  logger.info('render index');
-  response.render('pages/index');
-});
-
 // serve static assets
 app.use(express.static(__dirname + '/public'));
+
+// No explicit route for '/' so that express.static can serve index.html
 
 app.listen(app.get('port'), function() {
   logger.info('Node app is running', { port: app.get('port') });

--- a/test.js
+++ b/test.js
@@ -21,8 +21,8 @@ test('responds to requests', (t) => {
       // Successful response
       t.equal(response && response.statusCode, 200);
       // Assert content checks
-      t.notEqual(body.indexOf("<title>Node.js Getting Started on Heroku</title>"), -1);
-      t.notEqual(body.indexOf("Getting Started with Node on Heroku"), -1);
+      t.notEqual(body.indexOf('<title>Innovation Foundry</title>'), -1);
+      t.notEqual(body.indexOf('<h1><img src="images/logo.png" height="12" width="12"><a href="index.html"> Innovation Foundry</a></h1>'), -1);
     });
   }, 500);
 });


### PR DESCRIPTION
## Summary
- Remove Express root route so `/` is served by `public/index.html`
- Restore original landing page HTML
- Update tests to verify Innovation Foundry content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891a76443f88327ad3ecfd99461ff94